### PR TITLE
jquery chosen: trigger 'changed' on chosens with create_option: true

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -436,6 +436,7 @@ class Chosen extends AbstractChosen
     option = $('<option />', options ).attr('selected', 'selected')
     @form_field_jq.append option
     @form_field_jq.trigger "chosen:updated"
+    @form_field_jq.trigger "change"
     #@active_field = false
     @search_field.trigger('focus')
 


### PR DESCRIPTION
This strikes me as an oversight. The chosen's original select field does
not trigger 'change' when a custom entry is added and selected.
