### PR TITLE
Support pasting multiple options

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -365,6 +365,13 @@ class Chosen extends AbstractChosen
       @form_field_jq.trigger "change", {'selected': @form_field.options[item.options_index].value} if @is_multiple || @form_field.selectedIndex != @current_selectedIndex
       @current_selectedIndex = @form_field.selectedIndex
       this.search_field_scale()
+    else if @options.create_option == 'easy'
+      terms = $(".create-option").find("span").text()
+      if terms.trim()
+        this.select_create_option(terms)
+        this.close_field()
+        this.activate_field()
+        return
 
   single_set_selected_text: (text=@default_text) ->
     if text is @default_text
@@ -426,9 +433,10 @@ class Chosen extends AbstractChosen
       this.update_results_content(@options.custom_results)
 
   show_create_option: (terms) ->
-    create_option_html = $('<li class="create-option"><a href="javascript:void(0);">' + (@options.create_option_text||"Add option") + '</a>: "' + terms + '"</li>').bind "click", (evt) =>
+    create_option_html = $('<li class="create-option"><a href="javascript:void(0);">' + (@options.create_option_text||"Add option") + '</a>: "' + '<span>' + terms + '</span>' + '"</li>').bind "click", (evt) =>
       this.select_create_option(terms)
       this.close_field()
+      this.activate_field()
       evt.stopPropagation()
     @search_results.append create_option_html
 
@@ -444,8 +452,7 @@ class Chosen extends AbstractChosen
   select_append_option: ( options ) ->
     option = $('<option />', options ).attr('selected', 'selected')
     @form_field_jq.append option
-    @form_field_jq.trigger "chosen:updated"
-    @form_field_jq.trigger "change"
+    @form_field_jq.trigger("chosen:updated").trigger('change')
     #@active_field = false
     @search_field.trigger('focus')
 

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -95,6 +95,8 @@ class Chosen extends AbstractChosen
     @search_field.bind 'focus.chosen', (evt) => this.input_focus(evt); return
 
     if @is_multiple
+      if @options.create_option
+        @search_field.bind('paste.chosen', (evt) => this.handle_paste_multiple(evt))
       @search_choices.bind 'click.chosen', (evt) => this.choices_click(evt); return
     else
       @container.bind 'click.chosen', (evt) -> evt.preventDefault(); return # gobble click of anchor

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -416,6 +416,13 @@ class Chosen extends AbstractChosen
     if @options.create_option #and not selected
       this.show_create_option( terms )
 
+  show_custom_results: (terms) ->
+    if $.isFunction(@options.custom_results)
+      custom_html = @options.custom_results.call this, terms, this.select_append_option, this
+      this.update_results_content(custom_html)
+    else
+      this.update_results_content(@options.custom_results)
+
   show_create_option: (terms) ->
     create_option_html = $('<li class="create-option"><a href="javascript:void(0);">' + (@options.create_option_text||"Add option") + '</a>: "' + terms + '"</li>').bind "click", (evt) =>
       this.select_create_option(terms)

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -173,6 +173,10 @@ class AbstractChosen
 
     this.result_clear_highlight()
 
+    if @options.custom_results
+      this.show_custom_results(searchText)
+      return this.winnow_results_set_highlight()
+
     if results < 1 and searchText.length
       this.update_results_content ""
       this.no_results searchText

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -54,6 +54,29 @@ class AbstractChosen
       @active_field = false
       setTimeout (=> this.blur_test()), 100
 
+  handle_paste_multiple: (evt) ->
+    content = evt.originalEvent.clipboardData.getData('text')
+    if (content && content.match(/\n/))
+      evt.preventDefault()
+      evt.stopPropagation()
+
+      makeOrSelectOption = (item) =>
+        new_item = item.toString()
+        match_value = new_item.replace(/"/g, '\\"')
+        existing = @form_field_jq.find('option[value="' + match_value + '"]')
+        if (existing.length == 0)
+          option = $('<option />', { value: new_item, text: new_item }).prop('selected', true)
+          @form_field_jq.append(option)
+        else
+          existing.prop('selected', true)
+
+      lines = (line.replace(/^\s*|\s*$/g, '') for line in content.split(/\n/))
+      makeOrSelectOption(line) for line in lines when line.length > 0
+
+      @form_field_jq.trigger "chosen:updated"
+      @form_field_jq.trigger "change"
+      @search_field.trigger "focus"
+
   results_option_build: (options) ->
     content = ''
     for data in @results_data


### PR DESCRIPTION
If show_create_option and is_multiple are enabled, let people paste in
multiple options by pasting multiline content. The default behavior of a
text box is to join the lines with a space, but we can interrupt that
and parse them into multiple options.