### PR TITLE
Chosen.coffee: Add mki_disable_touch, mki_invisible_dropdowns  options

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -34,6 +34,7 @@ class Chosen extends AbstractChosen
     container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
     container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
     container_classes.push "chosen-rtl" if @is_rtl
+    container_classes.push "mki-chosen-invisible-dropdown" if @mki_invisible_dropdown
 
     container_props =
       'class': container_classes.join ' '
@@ -73,8 +74,9 @@ class Chosen extends AbstractChosen
     @form_field_jq.trigger("chosen:ready", {chosen: this})
 
   register_observers: ->
-    @container.bind 'touchstart.chosen', (evt) => this.container_mousedown(evt); evt.preventDefault()
-    @container.bind 'touchend.chosen', (evt) => this.container_mouseup(evt); evt.preventDefault()
+    if !@mki_disable_touch
+      @container.bind 'touchstart.chosen', (evt) => this.container_mousedown(evt); evt.preventDefault()
+      @container.bind 'touchend.chosen', (evt) => this.container_mouseup(evt); evt.preventDefault()
 
     @container.bind 'mousedown.chosen', (evt) => this.container_mousedown(evt); return
     @container.bind 'mouseup.chosen', (evt) => this.container_mouseup(evt); return
@@ -86,9 +88,10 @@ class Chosen extends AbstractChosen
     @search_results.bind 'mouseout.chosen', (evt) => this.search_results_mouseout(evt); return
     @search_results.bind 'mousewheel.chosen DOMMouseScroll.chosen', (evt) => this.search_results_mousewheel(evt); return
 
-    @search_results.bind 'touchstart.chosen', (evt) => this.search_results_touchstart(evt); return
-    @search_results.bind 'touchmove.chosen', (evt) => this.search_results_touchmove(evt); return
-    @search_results.bind 'touchend.chosen', (evt) => this.search_results_touchend(evt); return
+    if !@mki_disable_touch
+      @search_results.bind 'touchstart.chosen', (evt) => this.search_results_touchstart(evt); return
+      @search_results.bind 'touchmove.chosen', (evt) => this.search_results_touchmove(evt); return
+      @search_results.bind 'touchend.chosen', (evt) => this.search_results_touchend(evt); return
 
     @form_field_jq.bind "chosen:updated.chosen", (evt) => this.results_update_field(evt); return
     @form_field_jq.bind "chosen:activate.chosen", (evt) => this.activate_field(evt); return

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -34,6 +34,10 @@ class AbstractChosen
     @include_group_label_in_selected = @options.include_group_label_in_selected || false
     @max_shown_results = @options.max_shown_results || Number.POSITIVE_INFINITY
 
+    # Change rendering for situations when there are A LOT (e.g. 1500) chosen fields
+    @mki_invisible_dropdown = @options.mki_invisible_dropdown || false
+    @mki_disable_touch = @options.mki_disable_touch || false
+
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
       @default_text = @form_field.getAttribute("data-placeholder")


### PR DESCRIPTION
We were encountering significant slowdowns in initial rendering and
general lagginess when we had > 1000 .chosen-choice elements (the
colored pills).

`mki_disable_touch` is allowed to be {true, false, undefined}.
`mki_invisible_dropdowns` is allowed to be {true, false, undefined}.

This option makes the following optimizations currently:

  1) Do not bind any touch event handlers
  2) Add a css class 'mki-chosen-optimize'

In a separate css file, we have added made the dropdown use
`display:{none,block}` to replace `left:{-9999px,0px}`. This lowers the
rendering burden.