### PR TITLE
Fix bug in no_results

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -452,7 +452,7 @@ class Chosen extends AbstractChosen
     this.result_do_highlight do_high if do_high?
 
   no_results: (terms) ->
-    no_results_html = this.get_no_results_html(terms)
+    no_results_html = $(this.get_no_results_html(terms))
     no_results_html.find("span").first().html(terms)
     @search_results.append no_results_html
     @form_field_jq.trigger("chosen:no_results", {chosen:this})


### PR DESCRIPTION
The code was interacting with `no_results_html` as if it was a jQuery
object. When we upgraded to v1.7.0 the code changed from constructing
a jQuery object from an HTML string to using the `get_no_results_html`
method. This method only returns a string of HTML and hence we need to
wrap it in a call to jQuery to get the `.find` call to work.

<!---
Good pull requests — patches, improvements, new features — are a fantastic help.  They should remain focused in scope and avoid containing unrelated commits.

Please review the Pull Requests section of our Contributing Guidelines before submitting your work: https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests
-->

### Summary

Provide a general description of the code changes in your pull request.

Please double-check that:

  - [ ] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [ ] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [ ] You've updated both the jQuery *and* Prototype versions.
  - [ ] You haven't manually updated the version number in `package.json`.
  - [ ] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

See the [Pull Requests section of our Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more details.

### References

If your pull request is in reference to one or more open GitHub issues, please mention them here to keep the conversations linked together.
